### PR TITLE
Fixed broken link

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
             <li><a href="http://blogs.adb.org/blog/jargon-hurts-poor">Jargon hurts the poor</a></li>
             <li><a href="http://www.telegraph.co.uk/news/politics/9349970/Alan-Duncan-issues-memo-at-DFID-banning-jargon-words-like-going-forward.html">Alan Duncan issues memo at DFID banning jargon words such as 'going forward'</a></footer></li>
             <li><a href="http://www.whydev.org/9-development-phrases-we-hate-and-suggestions-for-a-new-lexicon/">9 development phrases we hate</a>
-            <li><a href="http://williameasterly.org/the-aidspeak-dictionary/">The Aidspeak Dictionary</a></li>
+            <li><a href="https://web.archive.org/web/20160327112038/http://williameasterly.org/the-aidspeak-dictionary/">The Aidspeak Dictionary</a></li>
           </ul>
 
           <h4>Is this serious?</h4>


### PR DESCRIPTION
Linked page http://williameasterly.org/the-aidspeak-dictionary isn't available anymore. Replacing with Wayback machine copy.
